### PR TITLE
feat(kugou): improve cover and shared playlist compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ GET /api
 |------|------|------|------|
 | `server` | string | 是 | 音乐平台:`netease`/`tencent`/`kugou`/`baidu`/`kuwo` |
 | `type` | string | 是 | 操作类型:`search`/`song`/`album`/`artist`/`playlist`/`lrc`/`url`/`pic` |
-| `id` | string | 是 | 资源 ID |
+| `id` | string | 是 | 资源 ID，或酷狗桌面歌单分享短码/链接 |
 | `token` 或 `auth` | string | 条件 | 认证令牌(仅 `lrc`/`url`/`pic` 类型需要) |
 
 ### 操作类型说明
@@ -225,6 +225,11 @@ curl "http://localhost:80/api?server=netease&type=search&id=周杰伦"
 curl "http://localhost:80/api?server=netease&type=song&id=歌曲ID"
 ```
 
+获取酷狗桌面分享歌单:
+```bash
+curl "http://localhost:80/api?server=kugou&type=playlist&id=7PUvhf0FZV2"
+```
+
 获取歌词(需要 token):
 ```bash
 curl "http://localhost:80/api?server=netease&type=lrc&id=歌曲ID&auth=计算的token"
@@ -256,10 +261,20 @@ const token = generateToken('netease', 'url', '123456');
 - 默认缓存容量:1000 条记录
 - 缓存时长:
   - `url` 类型:10 分钟
+  - 酷狗桌面分享歌单:30 秒
   - 其他类型:1 小时
 - 响应头 `x-cache`:
   - `miss`:缓存未命中,调用上游 API
   - 无此头:缓存命中
+
+## 酷狗兼容性增强
+
+- `pic` 在允许使用 Cookie 的情况下会优先通过酷狗 `songinfo` 补抓歌曲封面,避免部分歌曲返回歌手图
+- `playlist` 额外兼容酷狗桌面分享歌单,支持以下 `id` 形式:
+  - 分享短码,如 `7PUvhf0FZV2`
+  - `t1.kugou.com` 短链
+  - `wwwapi.kugou.com/share/zlist.html` 长链
+- 当上述兼容链路不适用或解析失败时,仍然回退到原有 `@meting/core` provider 逻辑
 
 ## Cookie 配置
 

--- a/src/service/api.js
+++ b/src/service/api.js
@@ -4,6 +4,12 @@ import { HTTPException } from '../utils/http-exception.js'
 import config from '../config.js'
 import { format as lyricFormat } from '../utils/lyric.js'
 import { readCookieFile, isAllowedHost } from '../utils/cookie.js'
+import { getKugouCoverFromSonginfo } from '../utils/kugou-songinfo.js'
+import {
+  canUseKugouSharePlaylist,
+  getKugouPlaylistFromShare,
+  normalizeKugouSharePlaylistInput
+} from '../utils/kugou-share-playlist.js'
 import { LRUCache } from 'lru-cache'
 
 const cache = new LRUCache({
@@ -27,8 +33,14 @@ export default async (request, ctx) => {
   const query = Object.fromEntries(url.searchParams)
   const server = query.server || 'netease'
   const type = query.type || 'search'
-  const id = query.id || 'hello'
+  let id = query.id || 'hello'
   const token = query.token || query.auth || 'token'
+
+  if (server === 'kugou' && type === 'playlist') {
+    id = normalizeKugouSharePlaylistInput(id) || id
+  }
+
+  const isKugouSharePlaylist = server === 'kugou' && type === 'playlist' && canUseKugouSharePlaylist(id)
 
   // 2. 校验参数
   if (!['netease', 'tencent', 'kugou', 'baidu', 'kuwo'].includes(server)) {
@@ -59,23 +71,40 @@ export default async (request, ctx) => {
       const cookie = await readCookieFile(server)
       if (cookie) {
         meting.cookie(cookie)
+
+        if (server === 'kugou' && type === 'pic') {
+          const cover = await getKugouCoverFromSonginfo({ hash: id, cookie, size: 400 })
+          if (cover) {
+            data = cover
+          }
+        }
       }
     }
 
-    const method = METING_METHODS[type]
-    let response
-    try {
-      response = await meting[method](id)
-    } catch {
-      throw new HTTPException(500, { message: '上游 API 调用失败' })
-    }
-    try {
-      data = JSON.parse(response)
-    } catch {
-      throw new HTTPException(500, { message: '上游 API 返回格式异常' })
+    if (data === undefined) {
+      if (isKugouSharePlaylist) {
+        data = await getKugouPlaylistFromShare(id)
+      }
+
+      if (data === undefined) {
+        const method = METING_METHODS[type]
+        let response
+        try {
+          response = await meting[method](id)
+        } catch {
+          throw new HTTPException(500, { message: '上游 API 调用失败' })
+        }
+        try {
+          data = JSON.parse(response)
+        } catch {
+          throw new HTTPException(500, { message: '上游 API 返回格式异常' })
+        }
+      }
     }
     cache.set(cacheKey, data, {
-      ttl: type === 'url' ? 1000 * 60 * 10 : 1000 * 60 * 60
+      ttl: isKugouSharePlaylist
+        ? 1000 * 30
+        : (type === 'url' ? 1000 * 60 * 10 : 1000 * 60 * 60)
     })
   }
 
@@ -125,13 +154,32 @@ export default async (request, ctx) => {
     })
   }
 
-  return Response.json(data.map(x => {
+  const safeData = Array.isArray(data) ? data : (data?.error ? [] : [data])
+  return Response.json(safeData.map(x => {
+    const title = x.name || x.songName || '未知歌曲'
+    let author = '未知歌手'
+    if (Array.isArray(x.artist)) {
+      author = x.artist.join(' / ')
+    } else if (Array.isArray(x.authors)) {
+      author = x.authors.map(a => a.author_name).join(' / ')
+    } else if (typeof x.singerName === 'string') {
+      author = x.singerName
+    }
+
+    const urlId = server === 'kugou'
+      ? (x.hash || x.url_id || id)
+      : (x.url_id || x.hash || id)
+    const picId = server === 'kugou'
+      ? (x.hash || x.pic_id || x.url_id || id)
+      : (x.pic_id || x.album_audio_id || x.albumid || x.hash || id)
+    const lrcId = x.lyric_id || x.hash || id
+
     return {
-      title: x.name,
-      author: x.artist.join(' / '),
-      url: `${config.meting.url}/api?server=${server}&type=url&id=${x.url_id}&auth=${auth(server, 'url', x.url_id)}`,
-      pic: `${config.meting.url}/api?server=${server}&type=pic&id=${x.pic_id}&auth=${auth(server, 'pic', x.pic_id)}`,
-      lrc: `${config.meting.url}/api?server=${server}&type=lrc&id=${x.lyric_id}&auth=${auth(server, 'lrc', x.lyric_id)}`
+      title,
+      author,
+      url: `${config.meting.url}/api?server=${server}&type=url&id=${urlId}&auth=${auth(server, 'url', urlId)}`,
+      pic: `${config.meting.url}/api?server=${server}&type=pic&id=${picId}&auth=${auth(server, 'pic', picId)}`,
+      lrc: `${config.meting.url}/api?server=${server}&type=lrc&id=${lrcId}&auth=${auth(server, 'lrc', lrcId)}`
     }
   }))
 }

--- a/src/utils/kugou-share-playlist.js
+++ b/src/utils/kugou-share-playlist.js
@@ -1,0 +1,135 @@
+const KUGOU_SHARE_HTML_PATTERNS = [
+  /var\s+dataFromSmarty\s*=\s*(\[[\s\S]*?\])\s*,\s*\/\//,
+  /var\s+dataFromSmarty\s*=\s*(\[[\s\S]*?\])\s*;/
+]
+
+const KUGOU_SHARE_HOSTS = new Set([
+  't1.kugou.com',
+  'wwwapi.kugou.com'
+])
+
+const KUGOU_SHARE_CODE_PATTERN = /^(?=.*[A-Za-z])[A-Za-z0-9]{8,}$/
+const FETCH_TIMEOUT_MS = 15000
+
+const normalizeHash = value => String(value || '').trim().toUpperCase()
+
+function normalizeShareInput (value) {
+  if (!value || typeof value !== 'string') return null
+
+  const input = value.trim()
+  if (KUGOU_SHARE_CODE_PATTERN.test(input)) {
+    return `https://t1.kugou.com/${input}`
+  }
+
+  try {
+    const url = new URL(input)
+    const hostname = url.hostname.toLowerCase()
+    if (!KUGOU_SHARE_HOSTS.has(hostname)) return null
+
+    if (hostname === 't1.kugou.com') {
+      const code = url.pathname.replace(/^\//, '')
+      if (!KUGOU_SHARE_CODE_PATTERN.test(code)) return null
+      return `https://t1.kugou.com/${code}`
+    }
+
+    if (url.pathname !== '/share/zlist.html') return null
+
+    const chain = url.searchParams.get('chain') || ''
+    if (KUGOU_SHARE_CODE_PATTERN.test(chain)) {
+      return `https://t1.kugou.com/${chain}`
+    }
+
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+function parseSharePlaylistData (html) {
+  if (!html) return []
+
+  for (const pattern of KUGOU_SHARE_HTML_PATTERNS) {
+    const match = html.match(pattern)
+    if (!match) continue
+
+    try {
+      const parsed = JSON.parse(match[1])
+      if (Array.isArray(parsed)) return parsed
+    } catch {}
+  }
+
+  return []
+}
+
+function normalizeShareSongs (items) {
+  const songs = []
+  const seen = new Set()
+
+  for (const item of items) {
+    const hash = normalizeHash(item?.hash)
+    if (!hash || seen.has(hash)) continue
+    seen.add(hash)
+
+    const artist = String(item?.author_name || '').trim()
+    songs.push({
+      name: String(item?.song_name || '').trim(),
+      artist: artist ? [artist] : [],
+      album: '',
+      album_id: String(item?.album_id || '').trim(),
+      hash,
+      source: 'kugou-share'
+    })
+  }
+
+  return songs
+}
+
+async function fetchText (url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+  try {
+    const response = await fetch(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36'
+      }
+    })
+
+    if (!response.ok) return null
+
+    return {
+      url: response.url,
+      html: await response.text()
+    }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export function canUseKugouSharePlaylist (value) {
+  return Boolean(normalizeShareInput(value))
+}
+
+export function normalizeKugouSharePlaylistInput (value) {
+  return normalizeShareInput(value)
+}
+
+export async function getKugouPlaylistFromShare (value) {
+  const normalizedInput = normalizeShareInput(value)
+  if (!normalizedInput) return null
+
+  const response = await fetchText(normalizedInput)
+  if (!response) return null
+
+  const finalUrl = response.url || normalizedInput
+  if (!normalizeShareInput(finalUrl)) return null
+
+  const items = parseSharePlaylistData(response.html)
+  if (items.length === 0) return null
+
+  return normalizeShareSongs(items)
+}

--- a/src/utils/kugou-songinfo.js
+++ b/src/utils/kugou-songinfo.js
@@ -1,0 +1,113 @@
+import { createHash } from 'node:crypto'
+
+const SIGN_KEY = 'NVPh5oo715z5DIWAeQlhMDsWXXQV4hwt'
+
+function parseCookie (cookie = '') {
+  const out = {}
+  for (const part of cookie.split(';')) {
+    const item = part.trim()
+    if (!item) continue
+
+    const index = item.indexOf('=')
+    if (index === -1) continue
+
+    const key = item.slice(0, index).trim()
+    const value = item.slice(index + 1).trim()
+    if (!key) continue
+    out[key] = value
+  }
+
+  return out
+}
+
+function signature (params) {
+  const sorted = Object.entries(params)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')
+    .split('&')
+    .sort()
+    .join('')
+
+  return createHash('md5')
+    .update(`${SIGN_KEY}${sorted}${SIGN_KEY}`)
+    .digest('hex')
+}
+
+function buildSonginfoUrl (params) {
+  const query = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    query.set(key, String(value))
+  }
+  query.set('signature', signature(params))
+  return `https://wwwapi.kugou.com/play/songinfo?${query.toString()}`
+}
+
+function normalizeCoverUrl (value, size = 400) {
+  if (!value) return ''
+
+  let result = String(value)
+  if (result.includes('{size}')) {
+    result = result.replace('{size}', String(size))
+  }
+  if (result.startsWith('http://')) {
+    result = `https://${result.slice('http://'.length)}`
+  }
+
+  return result
+}
+
+async function getKugouSonginfo ({ hash, cookie }) {
+  if (!hash || !cookie) return null
+
+  const parsed = parseCookie(cookie)
+  const token = parsed.t || ''
+  const userId = parsed.KugooID || ''
+  if (!token || !userId) return null
+
+  const mid = parsed.mid || parsed.kg_mid || ''
+  const dfid = parsed.dfid || parsed.kg_dfid || ''
+  const uuid = parsed.uuid || mid
+  const now = Date.now()
+
+  const params = {
+    srcappid: '2919',
+    clientver: '20000',
+    clienttime: String(now),
+    mid,
+    uuid,
+    dfid,
+    appid: '1014',
+    platid: '4',
+    hash: String(hash).toUpperCase(),
+    token,
+    userid: userId
+  }
+
+  try {
+    const response = await fetch(buildSonginfoUrl(params), {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+        'User-Agent': 'Mozilla/5.0',
+        Cookie: cookie
+      }
+    })
+
+    if (!response.ok) return null
+
+    const json = await response.json()
+    const data = json && typeof json === 'object' ? json.data : null
+    return data && typeof data === 'object' ? data : null
+  } catch {
+    return null
+  }
+}
+
+export async function getKugouCoverFromSonginfo ({ hash, cookie, size = 400 }) {
+  const data = await getKugouSonginfo({ hash, cookie })
+  if (!data) return null
+
+  const cover = data.trans_param?.union_cover || data.sizable_cover || data.img || ''
+  const url = normalizeCoverUrl(cover, size)
+  return url ? { url } : null
+}


### PR DESCRIPTION
提升酷狗 pic 准确度：在提供 cookie 时，优先通过 songinfo 获取歌曲的封面数据，而非之前的歌手封面。
新增对酷狗桌面版分享歌单（t1.kugou.com / wwwapi.kugou.com/share/zlist.html）的兼容支持 。
以上均在无法获取时回退至之前的方法，当新增的兼容逻辑不适用或未返回数据时，保留原有 @meting/core provider 逻辑作为 fallback。

本 PR 主要解决实际使用中发现的两个酷狗接口兼容性问题：
部分 pic 请求会解析为歌手头像而非歌曲封面。
本次修改新增了基于酷狗 songinfo 的封面获取路径，且仅在传入有效酷狗 cookie 时启用。如果获取失败，则维持原 provider 行为不变。
当前 provider 逻辑无法稳定处理酷狗桌面端分享的歌单。
本 PR 针对公开分享的歌单页面新增了一个轻量级解析器，支持以下格式：
分享码，例如 7PUvhf0FZV2
https://t1.kugou.com/...
https://wwwapi.kugou.com/share/zlist.html?...
如果该解析器不可用或未提取到歌曲信息，请求将回退至现有的 provider 实现。

注意事项
为减少获取到过期数据，酷狗分享歌单采用了较短的缓存时间（TTL 设为 30 秒）。